### PR TITLE
No AST !== Runtime Exceeded Error

### DIFF
--- a/src/components/Repl/Assignment.jsx
+++ b/src/components/Repl/Assignment.jsx
@@ -16,7 +16,7 @@ export default class Error extends React.Component {
     return (
       <div className='result'>
         <div className="result-inner">
-          <span>{this.props.children}</span>
+          <span title={this.props.children}>{this.props.children}</span>
           <div><i>{` <assignment>`}</i></div>
         </div>
       </div>

--- a/src/components/Repl/Computation.jsx
+++ b/src/components/Repl/Computation.jsx
@@ -30,7 +30,7 @@ export default class Computation extends React.Component {
     return (
       <div className='result'>
         <div className="result-inner">
-          <span>{this.props.children}</span>
+          <span title={this.props.children}>{this.props.children}</span>
           <div>
             <i>{renderedAddlInfo}</i>
             <span onClick={this.handleButtonClick} className='expand-collapse-button'>

--- a/src/components/Repl/Error.jsx
+++ b/src/components/Repl/Error.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
-import { leftmostOutermostRedex, renderExpression } from '../../lib/lambda';
+import {
+  leftmostOutermostRedex,
+  renderExpression,
+} from '../../lib/lambda';
 
 // Quick and dirty expansion of errors, because i forgot to go through
 // everything before submitting this somewhere
 
 const shownSteps = 25;
 
-function buildErrorMetadata(ast){
+function showFirstNSteps(ast){
   const firstSteps = [ ast ];
   for (let i = 0; i < shownSteps; i++){
     firstSteps.push(ast && leftmostOutermostRedex(firstSteps[firstSteps.length - 1]));
@@ -41,13 +44,19 @@ export default class Error extends React.Component {
   }
 
   render(){
-    const {ast} = this.props;
+    const {ast, error} = this.props;
+    
+    let buildErrorMetadata;
+    if (error.name === 'LambdaExecutionTimeoutError') {
+      buildErrorMetadata = showFirstNSteps;
+    }
+
     return (
       <span className='error'>
         <div>
           <div className="result-inner">
             <span>{this.props.children}</span>
-            {ast && ( // implicitly selects runtime errors, kinda shitty
+            {buildErrorMetadata && ( // implicitly selects runtime errors, kinda shitty
               <div>
                 <span onClick={this.handleButtonClick} className='expand-collapse-button'>
                   {this.state.expanded ? '(-)' : '(+)'}

--- a/src/components/Repl/Error.jsx
+++ b/src/components/Repl/Error.jsx
@@ -45,6 +45,7 @@ export default class Error extends React.Component {
     const {ast, error} = this.props;
     
     let buildErrorMetadata;
+    // would prefer instanceof, but i think babel has a bug
     if (error.name === 'LambdaExecutionTimeoutError') {
       buildErrorMetadata = showFirstNSteps;
     }

--- a/src/components/Repl/Error.jsx
+++ b/src/components/Repl/Error.jsx
@@ -52,7 +52,7 @@ export default class Error extends React.Component {
     return (
       <div className='error'>
         <div className="result-inner">
-          <span>{this.props.children}</span>
+          <span title={this.props.children}>{this.props.children}</span>
           {buildErrorMetadata && ( // implicitly selects runtime errors, kinda shitty
             <div>
               <span onClick={this.handleButtonClick} className='expand-collapse-button'>
@@ -61,7 +61,7 @@ export default class Error extends React.Component {
             </div>
           )}
         </div>
-        {this.state.expanded && buildErrorMetadata(ast)}
+        {this.state.expanded && buildErrorMetadata && buildErrorMetadata(ast)}
       </div>
     );
   }

--- a/src/components/Repl/index.jsx
+++ b/src/components/Repl/index.jsx
@@ -35,7 +35,7 @@ const renderEvaluation = (evaluation) => {
     }
     case 'error': {
       const { error, ast } = evaluation;
-      return ( <Error ast={ast}>{error.message}</Error> );
+      return ( <Error ast={ast} error={error}>{error.message}</Error> );
     }
     case 'info': {
       const { message } = evaluation;

--- a/src/lambdaActor/errors.js
+++ b/src/lambdaActor/errors.js
@@ -1,0 +1,6 @@
+export class FreeVarInDefinitionError extends Error {
+    constructor(message){
+        super(message);
+        this.name = 'FreeVarInDefinitionError';
+    }
+}

--- a/src/lambdaActor/executionContext.js
+++ b/src/lambdaActor/executionContext.js
@@ -3,6 +3,7 @@
 // import TimeoutWatcher from './TimeoutWatcher';
 // stick these in on move to async interface.
 import astToMetadata from './astToMetadata';
+import { FreeVarInDefinitionError } from './errors';
 
 import {
   parseExtendedSyntax,
@@ -44,7 +45,7 @@ class ExecutionContext {
   defineVariable(name, ast){
     if(this.getUnresolvableVariables(ast).length > 0){
       const unresolvables = this.getUnresolvableVariables(ast).join(', ');
-      throw({ message: 'Name Error: Expression contains free variables ' + unresolvables + '. Assigned values cannot have free variables in this REPL.' });
+      throw new FreeVarInDefinitionError('Name Error: Expression contains free variables ' + unresolvables + '. Assigned values cannot have free variables in this REPL.');
     }
     this.definedVariables[name] = ast;
   }

--- a/src/lib/lambda/errors.ts
+++ b/src/lib/lambda/errors.ts
@@ -1,0 +1,20 @@
+export class LambdaSyntaxError extends Error {
+    constructor(message){
+        super('Syntax Error: ' + message);
+        this.name = 'LambdaSyntaxError';
+    }
+}
+
+export class LambdaLexingError extends Error {
+    constructor(message){
+        super('Lexing Error: ' + message);
+        this.name = 'LambdaLexingError';
+    }
+}
+
+export class LambdaExecutionTimeoutError extends Error {
+    constructor(message){
+        super(message);
+        this.name = 'LambdaExecutionTimeoutError';
+    }
+}

--- a/src/lib/lambda/index.ts
+++ b/src/lib/lambda/index.ts
@@ -9,6 +9,7 @@ import { bReduce, eReduce, replace } from './operations';
 import { toNormalForm, leftmostOutermostRedex } from './normalize';
 import { tokenize } from './lexer';
 import { equal } from './equality';
+import { LambdaSyntaxError, LambdaLexingError, LambdaExecutionTimeoutError } from './errors';
 
 export {
   parseTerm,
@@ -25,4 +26,7 @@ export {
   replace,
   equal,
   purgeAstCache,
+  LambdaSyntaxError,
+  LambdaLexingError,
+  LambdaExecutionTimeoutError
 }

--- a/src/lib/lambda/lexer.ts
+++ b/src/lib/lambda/lexer.ts
@@ -66,7 +66,7 @@ function tokenize(str: string) : LambdaToken[] {
       const lower = Math.max(pos - excerptPadding, 0);
       const upper = Math.min(pos + excerptPadding, str.length);
       const excerpt = str.slice(lower, upper);
-      throw new LambdaLexingError(`Lexing Error: unexpected character at ${pos}: ${excerpt}`);
+      throw new LambdaLexingError(`Unexpected character at ${pos}: ${excerpt}`);
     }
   }
   return tokenStream;

--- a/src/lib/lambda/lexer.ts
+++ b/src/lib/lambda/lexer.ts
@@ -1,4 +1,5 @@
 import { LambdaToken } from './types';
+import { LambdaLexingError } from './errors';
 
 // idk i'm just guessing here. If you want something, just add it and i'll probs approve it
 const validSingleChars = /[a-zα-κμ-ω+\!\-\|\&]/;
@@ -54,7 +55,7 @@ function tokenize(str: string) : LambdaToken[] {
     } else if(nextChar === ':'){
       pos++;
       if (str[pos] !== '=') {
-        throw { message: 'Lexing Error: \'=\' expected after :' };
+        throw new LambdaLexingError('\'=\' expected after :');
       }
       tokenStream.push({
         type: 'assignment',
@@ -65,7 +66,7 @@ function tokenize(str: string) : LambdaToken[] {
       const lower = Math.max(pos - excerptPadding, 0);
       const upper = Math.min(pos + excerptPadding, str.length);
       const excerpt = str.slice(lower, upper);
-      throw { message: `Lexing Error: unexpected character at ${pos}: ${excerpt}` };
+      throw new LambdaLexingError(`Lexing Error: unexpected character at ${pos}: ${excerpt}`);
     }
   }
   return tokenStream;

--- a/src/lib/lambda/normalize.ts
+++ b/src/lib/lambda/normalize.ts
@@ -1,5 +1,6 @@
 import { LambdaExpression as Expr, Maybe } from './types';
 import { bReducable, bReduce } from './operations';
+import { LambdaExecutionTimeoutError } from './errors';
 
 function toNormalForm(
     expression : Expr,
@@ -13,7 +14,7 @@ function toNormalForm(
     reduced = leftmostOutermostRedex(current);
     count++;
     if (count >= depthOverflow) {
-      throw { message: 'Runtime error: normal form execution exceeded' };
+      throw new LambdaExecutionTimeoutError('Runtime error: normal form execution exceeded');
     }
   } while (reduced !== undefined);
   return current;

--- a/src/lib/lambda/parser.ts
+++ b/src/lib/lambda/parser.ts
@@ -4,6 +4,8 @@ import {
   LambdaToken as Token,
 } from './types';
 import { tokenize } from './lexer';
+import { LambdaSyntaxError } from './errors';
+
 
 // this one'll be a better entry point
 // LambdaToken[] -> Statement (because the typechecker is missing vast swathes of things.)
@@ -23,7 +25,7 @@ export function parseStatement(tokenStream : Token[] ) : Statement {
 
 export function parseExpression(tokenStream : Token[]) : Expr {
   if(tokenStream.length === 0){
-    throw({ message: 'Syntax Error: Empty Expression'});
+    throw new LambdaSyntaxError('Empty Expression');
   }
   let expression, rest;
   [expression, rest] = popExpression(tokenStream);
@@ -55,22 +57,22 @@ function popExpression(tokenStream) : [Expr, Token[]] {
     case 'lambda':
       // scan forward to find the dot, add in arguments
       if(tokenStream.length < 2) {
-        throw({ message: 'Syntax Error: Unexpected end of lambda' });
+        throw new LambdaSyntaxError('Unexpected end of lambda');
       }
       let dotPosition = 1;
       while(tokenStream[dotPosition].type !== 'dot') {
         if(tokenStream[dotPosition].type !== 'identifier'){
-          throw({ message: 'Syntax Error: non-identifier in argument stream'});
+          throw new LambdaSyntaxError('Non-identifier in argument stream');
         }
         dotPosition++;
         if (dotPosition >= tokenStream.length){
-          throw({ message: 'Syntax Error: Unexpected end of lambda'});
+          throw new LambdaSyntaxError('Unexpected end of lambda');
         }
       }
 
       const args = tokenStream.slice(1, dotPosition);
       if(args.length === 0){
-        throw({ message: 'Syntax Error: Bad number of arguments'});
+        throw new LambdaSyntaxError('Bad number of arguments');
       }
       const childExp = parseExpression(tokenStream.slice(dotPosition + 1));
       const exp = args.reduceRight((acc, cur) => ({
@@ -99,14 +101,14 @@ function popExpression(tokenStream) : [Expr, Token[]] {
         }
       }
       if (splitPoint < 0) {
-        throw({ message: 'Syntax Error: Unmatched Paren' });
+        throw new LambdaSyntaxError('Unmatched Paren');
       }
       return [
         parseExpression(tokenStream.slice(1, splitPoint - 1)),
         tokenStream.slice(splitPoint)
       ]
     default:
-      throw({ message: 'Syntax Error: Unexpected Token'});
+      throw new LambdaSyntaxError('Syntax Error: Unexpected Token');
   }
 }
 

--- a/src/lib/lambda/parser.ts
+++ b/src/lib/lambda/parser.ts
@@ -108,7 +108,7 @@ function popExpression(tokenStream) : [Expr, Token[]] {
         tokenStream.slice(splitPoint)
       ]
     default:
-      throw new LambdaSyntaxError('Syntax Error: Unexpected Token');
+      throw new LambdaSyntaxError('Unexpected Token');
   }
 }
 


### PR DESCRIPTION
Addresses https://github.com/evinism/lambda-explorer/issues/74

This is a dumb bug because i made a dumb assumption about errors a long time ago and never put in something more robust. A partial implementation so far, could use cleanup + a good ui given that error text for name error overflows on almost every monitor imaginable

### Changes
- Removes the (+) expand button from anything but runtime exceeded errors
- Gives us a title such that we can hover
- Gives us a cleaner way of expanding different errors. Imagine contextful / helpful / unobtrusive syntax errors and lexing errors!

In the future I'd love to make it so you can expand an error to see the full text bc right now how it is is dumb.
