### PR TITLE
change imports to more modern explicit import method, adopt tsx

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/mocharc.json",
+  "require": "tsx",
+  "spec": "src/**/*.spec.js"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "questy": "^1.1.1",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.2",
+        "tsx": "^4.19.1",
         "typescript": "^5.3.3",
         "webpack": "^5.89.0",
         "webpack-cli": "^5.1.4",
@@ -1867,6 +1868,390 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -3437,6 +3822,45 @@
       "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
       "dev": true
     },
+    "node_modules/esbuild": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -3880,6 +4304,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
+      "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -5586,6 +6022,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -6408,6 +6853,25 @@
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
       "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
+    },
+    "node_modules/tsx": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.1.tgz",
+      "integrity": "sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.23.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "exploration in webdev",
   "repository": "https://github.com/evinism/lambda-explorer",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "watch": "webpack --watch",
     "dev": "webpack-dev-server --port 8082 --static public --mode=development",
     "webpack": "webpack",
-    "test": "mocha -r ts-node/register -r @babel/register src/util/testhelper.js"
+    "test": "mocha"
   },
   "author": "evin",
   "license": "MIT",
@@ -20,9 +21,8 @@
     "babel-loader": "^9.1.3",
     "chai": "^5.0.0",
     "mocha": "^10.2.0",
-    "questy": "^1.1.1",
     "ts-loader": "^9.5.1",
-    "ts-node": "^10.9.2",
+    "tsx": "^4.19.1",
     "typescript": "^5.3.3",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
 
-import ProblemPrompter from './ProblemPrompter';
-import Repl from '../Repl';
-
-import persistComponent from '../../util/persist';
-
-import LambdaInput from '../LambdaInput';
-import problems from '../../game/problems';
+import ProblemPrompter from "./ProblemPrompter.jsx";
+import Repl from "../Repl/index.jsx";
+import persistComponent from "../../util/persist.js";
+import problems from "../../game/problems/index.js";
 
 const StartPrompt = ({start}) => (
   <div>

--- a/src/components/Repl/Computation.jsx
+++ b/src/components/Repl/Computation.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Metadata from './LambdaMetadata';
+import Metadata from "./LambdaMetadata.jsx";
 
 export default class Computation extends React.Component {
   state = { expanded: false };

--- a/src/components/Repl/Error.jsx
+++ b/src/components/Repl/Error.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   leftmostOutermostRedex,
   renderExpression,
-} from '../../lib/lambda';
+} from "../../lib/lambda/index.ts";
 
 
 const shownSteps = 25;

--- a/src/components/Repl/LambdaMetadata.jsx
+++ b/src/components/Repl/LambdaMetadata.jsx
@@ -5,7 +5,7 @@ import {
   renderAsChurchNumeral,
   renderAsChurchBoolean,
   renderExpression,
-} from '../../lib/lambda';
+} from "../../lib/lambda/index.ts";
 
 const LambdaMetadata = ({ast, err}) => {
   if(!ast){

--- a/src/components/Repl/index.jsx
+++ b/src/components/Repl/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 
-import persistComponent from '../../util/persist';
+import persistComponent from "../../util/persist.js";
 
 import LambdaInput from '../LambdaInput';
 import LambdaActor from '../../lambdaActor/actor.js';
@@ -11,7 +11,10 @@ import Computation from './Computation';
 import Error from './Error'
 import Info from './Info';
 
-import { renderExpression, parseExtendedSyntax } from '../../lib/lambda';
+import {
+  renderExpression,
+  parseExtendedSyntax,
+} from "../../lib/lambda/index.ts";
 
 const initialOutput = (
   <Info>

--- a/src/game/inlineDefinitions/InlineDefinition.jsx
+++ b/src/game/inlineDefinitions/InlineDefinition.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactjsPopup from 'reactjs-popup';
-import definitions from './definitions';
+import definitions from "./definitions.js";
 
 
 export default ({entry, children}) => {

--- a/src/game/problems/index.js
+++ b/src/game/problems/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import InlineDefinition from '../inlineDefinitions/InlineDefinition';
+import InlineDefinition from "../inlineDefinitions/InlineDefinition.jsx";
 import {
   equal,
   parseTerm as parse,
@@ -11,7 +11,7 @@ import {
   renderExpression,
   renderAsChurchNumeral,
   renderAsChurchBoolean,
-} from '../../lib/lambda';
+} from "../../lib/lambda/index.ts";
 // interface for each should be roughly:
 /*
   {

--- a/src/lambdaActor/actor.js
+++ b/src/lambdaActor/actor.js
@@ -1,9 +1,9 @@
-import ExecutionContext from './executionContext';
+import ExecutionContext from "./executionContext.js";
 
 // a lite wrapper around the executionContext, with time limits hopefully imposed
 // termination should be necessary or something.
 export default class LambdaActor {
-  constructor(){
+  constructor() {
     this.executionContext = new ExecutionContext();
     this.executionContext.receive = this._postBack;
   }

--- a/src/lambdaActor/astToMetadata.js
+++ b/src/lambdaActor/astToMetadata.js
@@ -8,7 +8,7 @@ import {
   toNormalForm,
   leftmostOutermostRedex,
   tokenize,
-} from '../lib/lambda';
+} from "../lib/lambda/index.ts";
 
 function astToMetadata(ast){
   const freeVars = getFreeVars(ast);

--- a/src/lambdaActor/executionContext.js
+++ b/src/lambdaActor/executionContext.js
@@ -2,15 +2,15 @@
 // import MetadataWorker from 'worker-loader?inline!./worker.js';
 // import TimeoutWatcher from './TimeoutWatcher';
 // stick these in on move to async interface.
-import astToMetadata from './astToMetadata';
-import { FreeVarInDefinitionError } from './errors';
+import astToMetadata from "./astToMetadata.js";
+import { FreeVarInDefinitionError } from "./errors.js";
 
 import {
   parseExtendedSyntax,
   getFreeVars,
   replace,
   toNormalForm,
-} from '../lib/lambda';
+} from "../lib/lambda/index.ts";
 
 // There's a better way of doing this I swear.
 // Might want to make a whole "Execution" object

--- a/src/lambdaActor/worker.js
+++ b/src/lambdaActor/worker.js
@@ -1,5 +1,5 @@
 // should be moved back probs.
-import astToMetadata from './astToMetadata';
+import astToMetadata from "./astToMetadata.js";
 
 onmessage = function(e) {
   const { ast, text } = JSON.parse(e.data);

--- a/src/lib/lambda/__tests__/bReduction.spec.js
+++ b/src/lib/lambda/__tests__/bReduction.spec.js
@@ -1,7 +1,7 @@
 import { assert } from "chai";
-import { bReduce } from "../operations";
-import { purgeAstCache } from "../util";
-import { parseTerm } from "../parser";
+import { bReduce } from "../operations.js";
+import { purgeAstCache } from "../util.js";
+import { parseTerm } from "../parser.js";
 
 describe("Beta Reductions", function () {
   it("Beta reduces a redex", function () {

--- a/src/lib/lambda/__tests__/cannonize.spec.js
+++ b/src/lib/lambda/__tests__/cannonize.spec.js
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { cannonize } from '../cannonize';
+import { cannonize } from "../cannonize.js";
 
 describe('Cannonize', function(){
   it('cannonizes two alpha-equivalent church numerals equivalently', function(done){

--- a/src/lib/lambda/__tests__/generated_suite.spec.js
+++ b/src/lib/lambda/__tests__/generated_suite.spec.js
@@ -1,9 +1,8 @@
 import { assert } from 'chai';
-import { resetEpsilonCounter } from '../operations';
-import { toNormalForm } from '../normalize';
-import { parseTerm } from '../parser';
-import { purgeAstCache } from '../util';
-import suiteData from './generated_suite.data.js';
+import { toNormalForm } from "../normalize.js";
+import { parseTerm } from "../parser.js";
+import { purgeAstCache } from "../util.js";
+import suiteData from "./generated_suite.data.js";
 
 /*
   Tests evaluation of expressions end to end based on previous versions.

--- a/src/lib/lambda/__tests__/lexer.spec.js
+++ b/src/lib/lambda/__tests__/lexer.spec.js
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { tokenize } from '../lexer';
+import { tokenize } from "../lexer.js";
 
 describe('Lexer', function(){
   it('should correctly lex all valid token types', function(done){

--- a/src/lib/lambda/__tests__/normalize.spec.js
+++ b/src/lib/lambda/__tests__/normalize.spec.js
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { toNormalForm, leftmostOutermostRedex } from '../normalize';
+import { toNormalForm, leftmostOutermostRedex } from "../normalize.js";
 
 describe('Normalize', function(){
   it('Handles top level beta reductions', function(done){

--- a/src/lib/lambda/__tests__/parser.spec.js
+++ b/src/lib/lambda/__tests__/parser.spec.js
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { parseExpression, parseStatement } from '../parser';
+import { parseExpression, parseStatement } from "../parser.js";
 
 describe('Parser', function(){
   it('correctly parses a lambda expression', function(done){

--- a/src/lib/lambda/__tests__/util.spec.js
+++ b/src/lib/lambda/__tests__/util.spec.js
@@ -1,6 +1,5 @@
 import { assert } from "chai";
-import { cacheOnAst, purgeAstCache } from "../util";
-import { LambdaExpression as Expr } from "../types";
+import { cacheOnAst, purgeAstCache } from "../util.js";
 
 describe("Caching Util", function () {
   it("creates cache keys on ASTs", function (done) {

--- a/src/util/generateGoldens.js
+++ b/src/util/generateGoldens.js
@@ -1,8 +1,8 @@
-import { parseTerm, toNormalForm, purgeAstCache } from '../lib/lambda';
+import { parseTerm, toNormalForm, purgeAstCache } from "../lib/lambda/index.ts";
 
-export default function generateGoldens(text){
-    return {
-        text,
-        normalForm: purgeAstCache(toNormalForm(parseTerm(text), 1000)),
-    };
+export default function generateGoldens(text) {
+  return {
+    text,
+    normalForm: purgeAstCache(toNormalForm(parseTerm(text), 1000)),
+  };
 }

--- a/src/util/testhelper.js
+++ b/src/util/testhelper.js
@@ -1,1 +1,0 @@
-const questy = require('questy')();

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,30 +1,31 @@
 module.exports = {
   context: __dirname + "/src",
-  entry: [
-    '@babel/polyfill',
-    './index',
-  ],
+  entry: ["@babel/polyfill", "./index"],
   output: {
     path: __dirname + "/public/build",
     filename: "bundle.js",
-    publicPath: "/build"
+    publicPath: "/build",
   },
   module: {
     rules: [
       {
         test: /\.jsx?$/,
-        loader: 'babel-loader',
+        loader: "babel-loader",
         exclude: /node_modules/,
       },
       {
         test: /\.tsx?$/,
-        loader: 'ts-loader',
+        loader: "ts-loader",
         exclude: /node_modules/,
-      }
+      },
     ],
   },
   resolve: {
-    extensions: ['.js', '.jsx', '.ts', '.tsx']
+    extensions: [".js", ".jsx", ".ts", ".tsx"],
+    extensionAlias: {
+      ".js": [".ts", ".js"],
+      ".mjs": [".mts", ".mjs"],
+    },
   },
-  devtool: 'source-map'
-}
+  devtool: "source-map",
+};


### PR DESCRIPTION
Switching to using `.js` filename imports due to tsc + explicit deps issues. Changing to TSX to support this. All in honor of getting functional tests in a modern environment. 